### PR TITLE
docs: expand neural benchmarking and deployment guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 **Ninja Gekko represents the evolutionary leap from traditional trading bots to a completely autonomous, self-improving trading intelligence powered by Rust performance and MCP ecosystem integration.**
 
-[🥷 Features](#-revolutionary-features) • [🚀 Quick Start](#-quick-start) • [🧠 Neural Stack](#-neural-intelligence-stack) • [🎭 MCP Integration](#-mcp-first-architecture) • [📈 Performance](#-performance-benchmarks)
+[🥷 Features](#-revolutionary-features) • [🚀 Quick Start](#-quick-start) • [🧠 Neural Stack](#-neural-intelligence-stack) • [🎭 MCP Integration](#-mcp-first-architecture) • [🤝 Capability Matrix](#-capability-matrix-ninja-gekko-vs-modern-neural-trading-stacks) • [🌐 Integrations](#-integration-coverage--roadmap) • [⚠️ Risk Disclosure](#-experimental-research-disclosure) • [📈 Performance](#-performance-benchmarks)
 
 </div>
 
@@ -45,6 +45,26 @@
 - **⚡ GPU Acceleration**: CUDA 11.8+ and Apple Metal Performance Shaders support
 - **🌐 WebAssembly Deployment**: Run anywhere - browser, edge, server, embedded
 
+> **Experimental Research Disclosure**: Ninja Gekko is experimental, open-source software provided for research and development only. Automated trading is inherently risky. Use at your own risk. Nothing in this repository constitutes financial advice.
+
+---
+
+## 🧠 **Neural Architecture Compatibility**
+
+Ninja Gekko unifies ruv-FANN, Neuro-Divergent, and industry-standard NeuralForecast models under a single benchmarking harness with GPU and CPU parity.
+
+| Model Family | Supported Variants | Benchmark Focus | Status |
+|--------------|--------------------|-----------------|--------|
+| **NHITS** | Multi-horizon time-series, custom attention heads | Latency <10ms, horizon stability | ✅ Production |
+| **N-BEATSx** | Seasonality/trend expert stacks | Forecast accuracy, regime resilience | ✅ Production |
+| **LSTM / GRU** | ruv-FANN recurrent suite | Cross-asset adaptability, training throughput | ✅ Production |
+| **Temporal Fusion Transformer** | TFT with multi-asset covariates | Explainability, feature attributions | 🚧 Preview |
+| **Dilated CNN (WaveNet)** | Residual dilated convolutions | Order book microstructure modelling | ✅ Production |
+| **ruv-FANN Neuro-Divergent** | Ensemble neuro-symbolic hybrids | Strategy consensus, swarm scoring | ✅ Production |
+| **Hybrid RL Agents** | Policy-gradient & actor-critic blends | Risk-adjusted Sharpe, live feedback loops | 🧪 Research |
+
+The forthcoming **Neural Benchmarking Module** captures inference latency, MAE/MAPE, and Sharpe/Sortino metrics across every supported architecture with reproducible evaluation manifests.
+
 ---
 
 ## 🥷 **Revolutionary Features**
@@ -62,7 +82,7 @@ Built on cutting-edge Rust-based neural network technology:
 | **🌐 WASM Runtime** | Browser & Edge | Universal deployment |
 
 ### **🎭 MCP-First Architecture**
-Native Model Context Protocol integration with 70+ servers:
+Native Model Context Protocol integration with 70+ servers, formalized as the **Tenno-MCP** runtime for plug-and-play agent composition. Tenno-MCP provides USB-C-like interoperability for LLMs, automation tools, and market adapters with declarative manifests, hot-reloadable toolchains, and CLI/server parity.
 
 #### **🔧 Core MCP Servers**
 - **🎪 Playwright MCP**: Advanced browser automation, web scraping, and market data collection
@@ -82,6 +102,8 @@ Native Model Context Protocol integration with 70+ servers:
 | **📱 Social Intelligence** | Twitter, Reddit, YouTube, LinkedIn | Social sentiment, news monitoring, trend analysis |
 | **🔧 DevOps** | GitHub, GitLab, Docker, NPM | CI/CD pipelines, deployment automation |
 
+Tenno-MCP now exposes a **Tool Orchestration Registry** inspired by Claude-Flow, enabling swarm agents to register capabilities, negotiate ownership, and coordinate workflows through consensus-driven leasing contracts.
+
 ### **🥷 Autonomous Operation Modes**
 
 #### **🌙 Stealth Mode**  
@@ -98,12 +120,52 @@ Native Model Context Protocol integration with 70+ servers:
 - Risk-adjusted position optimization using Kelly Criterion
 - Real-time volatility clustering and regime detection
 
-#### **🤖 Swarm Mode**  
+#### **🤖 Swarm Mode**
 *Collaborative intelligence across multiple agents*
 - Distributed decision-making with consensus algorithms
 - Cross-market arbitrage detection and execution
 - Coordinated strategies across different asset classes
 - Fault-tolerant operation with automatic failover
+- Tenno-MCP orchestration registry with role-based leasing and health-checked failover rotation
+- Claude-Flow compatible tool negotiation and shared scratchpad for context-rich execution plans
+
+---
+
+## 🤝 **Capability Matrix: Ninja Gekko vs Modern Neural Trading Stacks**
+
+| Feature | **Ninja Gekko** | Neural Trader MCP | Claude-Flow |
+|---------|-----------------|-------------------|-------------|
+| **Neural Forecasting Models** | ruv-FANN, Neuro-Divergent, NHITS, N-BEATSx, LSTM/GRU, WaveNet, TFT preview | NHITS, N-BEATSx, LSTM/GRU | Swarm-assisted inference |
+| **MCP Protocol** | Tenno-MCP with declarative tool manifests and USB-C-style plug-and-play | FastMCP core | Claude MCP/Flow orchestration |
+| **Agentic Swarm Orchestration** | ruv-swarm with tool registry, leasing, and consensus failover | 87+ tool hive-mind | Swarm coordination layer |
+| **Trading Venue Integrations** | Coinbase, Binance, Oanda, Alpaca (beta), Deribit, Kraken | Polymarket, Betfair, Alpaca, Alpha Vantage, TheOddsAPI | Customizable adapters |
+| **Telemetry & Observability** | Prometheus, Grafana, OpenTelemetry traces, ELK | JSON dashboards, custom telemetry | Flow-native dashboards |
+| **Security & Governance** | MFA, TLS 1.3, RBAC, audit ledger, GDPR-ready | KYC/RBAC, end-to-end encryption | Workspace roles |
+| **Benchmarking** | Built-in neural latency/Sharpe harness with reproducible manifests | Proprietary benchmarking suite | Scenario planners |
+| **Deployment Footprint** | Rust microservices, Docker/K8s, WASM | Rust/Python hybrid, Docker/K8s | Python-first orchestration |
+
+> Tenno-MCP emphasizes transparent, modular interoperability so that researchers can replicate or extend benchmarks across open-source trading stacks.
+
+---
+
+## 🌐 **Integration Coverage & Roadmap**
+
+| Domain | Live Integrations | Upcoming Targets | Notes |
+|--------|------------------|------------------|-------|
+| **Centralized Exchanges** | Coinbase, Binance, Kraken, Oanda | Interactive Brokers, Bitfinex | Unified order router with smart venue selection |
+| **Decentralized / Prediction Markets** | Uniswap (data), dYdX (execution) | Polymarket, Betfair Exchange, TheGraph | Workflow recipes under Tenno-MCP tool registry |
+| **Market Data & Analytics** | Alpha Vantage, Tiingo, TradingView, Glassnode | TheOddsAPI, Kaiko, Polygon.io | Multi-frequency data normalization pipelines |
+| **AI / ML Services** | OpenAI, HuggingFace, Replicate | Anthropic Claude-Flow, Cohere, StabilityAI | Shared embeddings cache across agents |
+| **Community & Ops** | Slack, Discord, Telegram, Notion | Linear, Jira, GitLab Issues | MCP-driven incident response bots |
+| **Compliance & Governance** | Supabase Auth, custom RBAC, audit ledger | KYC/AML providers, on-chain attestations | Policy-driven access enforced via Tenno-MCP |
+
+Deployment runbooks for Docker and Kubernetes clusters now include:
+
+- **Docker Compose Playbook**: Layered services for core trading engine, Tenno-MCP routers, observability, and GPU inference nodes.
+- **Kubernetes Guide**: GPU node pool setup, Horizontal Pod Autoscaling, Istio/Linkerd service mesh integration, and secure secret distribution.
+- **Benchmark Automation**: CI hooks to execute neural benchmarking manifests and publish Grafana dashboards.
+
+Detailed instructions live in [`docs/deployment/`](docs/deployment/) with step-by-step sandbox parity validation.
 
 ---
 
@@ -163,6 +225,12 @@ Native Model Context Protocol integration with 70+ servers:
 | **ML Integration** | GPU-accelerated models with continuous learning | <50ms inference |
 | **Market Data** | Multi-platform real-time feeds with validation | <5ms latency |
 | **Portfolio Management** | Automated rebalancing and optimization | 24/7 monitoring |
+
+---
+
+## ⚠️ **Experimental Research Disclosure**
+
+Ninja Gekko is experimental, open-source research software. Automated trading carries significant financial risk, including potential loss of capital. Validate configurations in sandbox environments, comply with jurisdictional regulations, and consult professional advisors before any production deployment. Nothing herein constitutes investment, trading, or financial advice.
 
 ---
 

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -1,0 +1,185 @@
+# Ninja Gekko Deployment Playbooks
+
+This guide documents reproducible deployment flows for the Ninja Gekko autonomous trading stack across containerized and Kubernetes environments. All steps assume access to the Tenno-MCP tool registry and the neural benchmarking harness introduced in the README.
+
+## Docker Compose Playbook
+
+1. **Prerequisites**
+   - Docker Engine 24+
+   - NVIDIA Container Toolkit (for GPU inference nodes)
+   - Access credentials for supported exchanges and data providers stored in `.env`
+2. **Bootstrap**
+   - Clone the repository and run `cargo build --release` for the core services if building locally.
+   - Copy the template below into `deploy/docker-compose.yml` (or another filename of your choosing).
+
+```yaml
+services:
+  tenno-mcp-router:
+    image: ghcr.io/ninja-gekko/tenno-mcp:latest
+    env_file: .env
+    ports:
+      - "8080:8080"
+  trading-engine:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    command: ["./target/release/ninja-gekko", "--mode", "swarm"]
+    depends_on:
+      - tenno-mcp-router
+  gpu-inference:
+    image: ghcr.io/ninja-gekko/neural-inference:latest
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: ["gpu"]
+  observability:
+    image: ghcr.io/ninja-gekko/observability:latest
+    ports:
+      - "3000:3000"
+```
+
+   - Execute `docker compose -f deploy/docker-compose.yml up -d` to launch the trading engine, Tenno-MCP router, observability stack, and GPU inference workers.
+3. **Post-Launch Validation**
+   - Confirm Tenno-MCP service discovery via `curl http://localhost:8080/mcp/health`.
+   - Review Prometheus and Grafana dashboards at `http://localhost:3000` for latency, Sharpe, and uptime metrics.
+   - Run the neural benchmarking harness with `cargo run --bin benchmarking -- --suite neural-default` to populate baseline metrics.
+
+## Kubernetes Guide
+
+1. **Cluster Requirements**
+   - Kubernetes 1.28+
+   - GPU-enabled node pool with NVIDIA device plugin or equivalent
+   - Istio or Linkerd for secure service mesh routing
+2. **Installation Steps**
+   - Create the following Kustomize structure (paths relative to the repository root):
+
+```text
+deploy/
+  k8s/
+    base/
+      kustomization.yaml
+      tenno-mcp-router.yaml
+      trading-engine.yaml
+    gpu/
+      kustomization.yaml
+      gpu-inference.yaml
+    hpa/
+      kustomization.yaml
+      trading-engine-hpa.yaml
+    benchmarks.yaml
+```
+
+   - Populate the manifests using the examples below, then apply them with `kubectl apply -k deploy/k8s/base`, `kubectl apply -k deploy/k8s/gpu`, and `kubectl apply -k deploy/k8s/hpa`.
+   - Configure Istio gateway and mTLS policies to secure MCP and trading ingress points.
+
+```yaml
+# deploy/k8s/base/tenno-mcp-router.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tenno-mcp-router
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: tenno-mcp-router
+  template:
+    metadata:
+      labels:
+        app: tenno-mcp-router
+    spec:
+      containers:
+        - name: router
+          image: ghcr.io/ninja-gekko/tenno-mcp:latest
+          ports:
+            - containerPort: 8080
+          envFrom:
+            - secretRef:
+                name: tenno-mcp-secrets
+---
+# deploy/k8s/base/trading-engine.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: trading-engine
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: trading-engine
+  template:
+    metadata:
+      labels:
+        app: trading-engine
+    spec:
+      containers:
+        - name: engine
+          image: ghcr.io/ninja-gekko/trading-engine:latest
+          args: ["--mode", "swarm"]
+          envFrom:
+            - secretRef:
+                name: trading-credentials
+---
+# deploy/k8s/gpu/gpu-inference.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gpu-inference
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gpu-inference
+  template:
+    metadata:
+      labels:
+        app: gpu-inference
+    spec:
+      containers:
+        - name: inference
+          image: ghcr.io/ninja-gekko/neural-inference:latest
+          resources:
+            limits:
+              nvidia.com/gpu: 1
+---
+# deploy/k8s/hpa/trading-engine-hpa.yaml
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: trading-engine-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: trading-engine
+  minReplicas: 3
+  maxReplicas: 15
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 60
+```
+3. **Operational Checks**
+   - Validate swarm agent registration through `kubectl logs deployment/tenno-mcp-router`.
+   - Inspect OpenTelemetry traces for end-to-end order lifecycles in Jaeger/Grafana Tempo.
+   - Schedule the benchmarking CronJob (`kubectl apply -f deploy/k8s/benchmarks.yaml`) to publish inference latency reports.
+
+## Benchmark Automation
+
+- Continuous integration workflows invoke `cargo run --bin benchmarking -- --suite regression` on each merge to the `main` branch.
+- Results are exported to Prometheus via the `benchmark-exporter` sidecar and visualized in Grafana (`dashboards/benchmarks.json`).
+- To compare against Neural Trader MCP or Claude-Flow baselines, import their metrics into the `comparison` data source and re-run the harness with the `--peer neural-trader` or `--peer claude-flow` flags.
+
+## Sandbox Parity Checklist
+
+- ✅ Tenno-MCP tool registry lists Playwright, Filesystem, GitHub, Supabase, and Search MCP services.
+- ✅ Neural benchmarking manifests match the versions tracked in your environment-specific configuration repository.
+- ✅ Docker and Kubernetes deployments emit identical telemetry labels, enabling shared dashboards and alerting rules.
+
+> **Reminder:** All deployments must be exercised in paper-trading or sandbox environments before real-capital execution. Adjust rate limits, risk controls, and compliance hooks per jurisdictional requirements.


### PR DESCRIPTION
## Summary
- expand the README with a neural architecture compatibility table, Tenno-MCP orchestration updates, a competitive capability matrix, and an explicit risk disclosure
- document integration coverage, benchmarking commitments, and link to new deployment playbooks
- add a deployment guide detailing docker compose, kubernetes, and benchmarking automation templates

## Testing
- no automated tests were run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d7f82ebe448333a6aef578f324bdc6